### PR TITLE
DerpLauncher: Add ACCESS_SURFACE_FLINGER permission to manifest

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -46,6 +46,7 @@
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" />
     <!-- for rotating surface by arbitrary degree -->
+    <uses-permission android:name="android.permission.ACCESS_SURFACE_FLINGER" />
     <uses-permission android:name="android.permission.ROTATE_SURFACE_FLINGER" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.DEVICE_POWER" />


### PR DESCRIPTION
Fixes
06-21 09:27:41.679   447   986 E SurfaceFlinger: Only WindowManager is allowed to use eEarlyWakeup[Start|End] flags